### PR TITLE
Specify `Option.of` return type as `NonNullable`

### DIFF
--- a/packages/funfix-core/src/disjunctions.ts
+++ b/packages/funfix-core/src/disjunctions.ts
@@ -873,7 +873,7 @@ export class Option<A> implements std.IEquals<Option<A>>, HK<"funfix/option", A>
    * If the given value is `null` or `undefined` then the returned
    * option will be empty.
    */
-  static of<A>(value: A | null | undefined): Option<A> {
+  static of<A>(value: A | null | undefined): Option<NonNullable<A>> {
     return value != null ? Some(value) : None
   }
 


### PR DESCRIPTION
Re. https://github.com/Microsoft/TypeScript/issues/19469#issuecomment-342230808

In TS, we have this issue:

``` ts
declare class Maybe<A> {
    static of<A>(value: A | undefined): Maybe<A>;
    map<B>(f: (a: A) => B): Maybe<B>;
}

{
    type User = { name: string };
    const logUser = (_user: User) => {};

    type State = {
        user: User | undefined;
    };

    const fn = function<Own extends {}>(p: Readonly<Own & State>) {
        const { user } = p;

        Maybe.of(user).map(
            user =>
                // Unexpected error: Object is possibly 'undefined'.
                user.name,
        );
    };
}
```

Annotating `Option.of` return type as `NonNullable`, as recommended in the TS issue, fixes this.